### PR TITLE
Fix: Fix Missing Documentation: Missing documentation: CalendarlyTests

### DIFF
--- a/calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
+++ b/calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
@@ -4,6 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+/**
+ * Main test class for the Calendarly application.
+ * Contains integration tests to verify the Spring Boot application context
+ * loads correctly and basic application functionality works as expected.
+ */
 class CalendarlyTests {
 
 	@Test


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Class 'CalendarlyTests' lacks Javadoc documentation.

**Solution:** The issue is still applicable. The `CalendarlyTests` class on line 6 lacks Javadoc documentation. This is a Spring Boot test class that needs proper documentation to explain its purpose. I'll add comprehensive Javadoc documentation that describes the class's role as the main test class for the Calendarly application.

**File:** calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
**Lines:** 6-6

Generated by RefloQ AI