### PR TITLE
Fix: Fix Missing Documentation: Missing documentation: contextLoads

### DIFF
--- a/calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
+++ b/calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
@@ -6,6 +6,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class CalendarlyTests {
 
+	/**
+	 * Test to verify that the Spring application context loads successfully.
+	 */
 	@Test
 	void contextLoads() {
 	}


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'contextLoads' lacks Javadoc documentation.

**Solution:** The issue is still applicable. The method `contextLoads()` on line 9 lacks Javadoc documentation. This is a standard Spring Boot test method that verifies the application context loads successfully. Adding proper Javadoc documentation will improve code maintainability and help other developers understand the purpose of this test method.

**File:** calendarly/src/test/java/com/p0/calendarly/CalendarlyTests.java
**Lines:** 9-9

Generated by RefloQ AI