### PR TITLE
Fix: Fix Dead Code: Unused method: updateBookings

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
@@ -16,8 +16,4 @@ public interface AvailabilityRepository extends JpaRepository<Availability, Long
     Availability save(Availability availability);
 
     List<Availability> findByUserId(Long userId);
-
-    @Modifying
-    @Query(value = "UPDATE availability SET bookings = :bookings WHERE id = :id", nativeQuery = true)
-    int updateBookings(@Param("bookings") List<Booking> bookings, @Param("id") Long availabilityId);
 }


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'updateBookings' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The `updateBookings` method on lines 20-22 is defined but never called anywhere in the codebase. This is dead code that should be removed to reduce technical debt. Additionally, the method has a design flaw - it attempts to update a `bookings` field using a `List<Booking>` parameter in a native SQL query, which would not work properly since you cannot directly pass a Java List to a native SQL UPDATE statement.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
**Lines:** 20-22

Generated by RefloQ AI