### PR TITLE
Fix: Fix Dead Code: Unused method: findByUserId

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
@@ -15,8 +15,6 @@ public interface AvailabilityRepository extends JpaRepository<Availability, Long
 
     Availability save(Availability availability);
 
-    List<Availability> findByUserId(Long userId);
-
     @Modifying
     @Query(value = "UPDATE availability SET bookings = :bookings WHERE id = :id", nativeQuery = true)
     int updateBookings(@Param("bookings") List<Booking> bookings, @Param("id") Long availabilityId);


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'findByUserId' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The method `findByUserId(Long userId)` on line 18 is defined in the AvailabilityRepository interface but is not being used anywhere in the codebase. This represents dead code that should be removed to reduce technical debt. The method appears to be redundant since there's already a more specific method `findByUserIdAndStartTimeBetween` that likely serves the actual use cases needed by the application.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
**Lines:** 18-18

Generated by RefloQ AI