### PR TITLE
Fix: Fix Dead Code: Unused method: findByUserIdAndStartTimeBetween

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 import java.util.List;
 
 public interface AvailabilityRepository extends JpaRepository<Availability, Long> {
-    List<Availability> findByUserIdAndStartTimeBetween(Long userId, Timestamp startTime, Timestamp endTime);
 
     Availability save(Availability availability);
 


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'findByUserIdAndStartTimeBetween' is defined but never called. Consider removing if not needed.

**Solution:** The method `findByUserIdAndStartTimeBetween` on line 14 is indeed defined but appears to be unused based on the issue description. This is dead code that should be removed to reduce technical debt and improve code maintainability. The method is a Spring Data JPA query method that finds availability records by user ID within a time range, but since it's not being called anywhere in the codebase, it can be safely removed.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
**Lines:** 14-14

Generated by RefloQ AI