### PR TITLE
Fix: Fix Dead Code: Unused method: save

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
@@ -13,8 +13,6 @@ import java.util.List;
 public interface AvailabilityRepository extends JpaRepository<Availability, Long> {
     List<Availability> findByUserIdAndStartTimeBetween(Long userId, Timestamp startTime, Timestamp endTime);
 
-    Availability save(Availability availability);
-
     List<Availability> findByUserId(Long userId);
 
     @Modifying


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'save' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The `save` method is explicitly declared in the `AvailabilityRepository` interface on line 16, but this is redundant since `JpaRepository<Availability, Long>` already provides a `save` method. In Spring Data JPA repositories, you don't need to explicitly declare methods that are already provided by the parent interface. The explicit declaration should be removed to eliminate dead code.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/AvailabilityRepository.java
**Lines:** 16-16

Generated by RefloQ AI