### PR TITLE
Fix: Fix Dead Code: Unused method: findByEmail

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/UserRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/UserRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 
 @Transactional
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'findByEmail' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The `findByEmail` method is defined in the UserRepository interface but is not being used anywhere in the codebase according to the technical debt report. Since this is dead code that serves no purpose, it should be removed to reduce technical debt and maintain a cleaner codebase.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/UserRepository.java
**Lines:** 11-11

Generated by RefloQ AI