### PR TITLE
Fix: Fix Dead Code: Unused method: findByAvailabilityIdIn

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
@@ -7,9 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface BookingRepository extends JpaRepository<Booking, Long> {
-    @EntityGraph(attributePaths = {"bookings"})
-    List<Booking> findByAvailabilityIdIn(List<Long> availabilityIds);
-    Booking save(Booking booking);
-
 }
 


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'findByAvailabilityIdIn' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The method `findByAvailabilityIdIn` is defined on lines 10-11 but is never called anywhere in the codebase. This is dead code that should be removed to reduce technical debt. Additionally, the `save` method on line 12 is redundant since it's already inherited from `JpaRepository<Booking, Long>` and doesn't add any custom behavior.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
**Lines:** 10-11

Generated by RefloQ AI