### PR TITLE
Fix: Fix Dead Code: Unused method: save

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
+++ b/calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
@@ -9,7 +9,6 @@ import java.util.List;
 public interface BookingRepository extends JpaRepository<Booking, Long> {
     @EntityGraph(attributePaths = {"bookings"})
     List<Booking> findByAvailabilityIdIn(List<Long> availabilityIds);
-    Booking save(Booking booking);
 
 }
 


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'save' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The `BookingRepository` interface explicitly declares a `save(Booking booking)` method on line 12, but this is redundant because `JpaRepository<Booking, Long>` already provides this method through inheritance. The explicit declaration is unnecessary dead code that should be removed to clean up the interface.

**File:** calendarly/src/main/java/com/p0/calendarly/repository/BookingRepository.java
**Lines:** 12-12

Generated by RefloQ AI