### PR TITLE
Fix: Fix Dead Code: Unused method: getStatus

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/enums/AvailabilityStatus.java
+++ b/calendarly/src/main/java/com/p0/calendarly/enums/AvailabilityStatus.java
@@ -3,15 +3,8 @@ package com.p0.calendarly.enums;
 public enum AvailabilityStatus {
     AVAILABLE("AVAILABLE"),
     BOOKED("BOOKED");
-
-    private final String status;
-
-    AvailabilityStatus(String status){
-        this.status = status;
-    }
-
-    public String getStatus(){
-        return status;
+    
+    AvailabilityStatus(){
     }
 
     @Override


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'getStatus' is defined but never called. Consider removing if not needed.

**Solution:** The `getStatus()` method is defined but never called, making it dead code. Since the enum constants already have meaningful names that match their string values, and the standard enum methods (`name()`, `toString()`) can be used to get string representations, the custom `getStatus()` method and its associated field are unnecessary and should be removed.

**File:** calendarly/src/main/java/com/p0/calendarly/enums/AvailabilityStatus.java
**Lines:** 13-15

Generated by RefloQ AI