### PR TITLE
Fix: Fix Dead Code: Unused method: getStatus

### DIFF
--- a/calendarly/src/main/java/com/p0/calendarly/enums/BookingStatus.java
+++ b/calendarly/src/main/java/com/p0/calendarly/enums/BookingStatus.java
@@ -3,17 +3,7 @@ package com.p0.calendarly.enums;
 public enum BookingStatus {
     PENDING("PENDING"),
     ACCEPTED("ACCEPTED"),
-    DECLINED("DECLINED");
-
-    private final String status;
-
-    BookingStatus(String status){
-        this.status = status;
-    }
-
-    public String getStatus(){
-        return status;
-    }
+    DECLINED("DECLINED")
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Technical Debt Fix

**Issue:** Method 'getStatus' is defined but never called. Consider removing if not needed.

**Solution:** The issue is still applicable. The `getStatus()` method on lines 14-16 is defined but never used, making it dead code. Since this is an enum with string values, the method is redundant because:
1. The enum constants themselves can be used directly
2. The `toString()` method is overridden (though it currently just calls super.toString())
3. If string representation is needed, `name()` method is available by default

The cleanest solution is to remove the unused `getStatus()` method and the redundant `status` field, simplifying the enum to just use the default enum behavior.

**File:** calendarly/src/main/java/com/p0/calendarly/enums/BookingStatus.java
**Lines:** 14-16

Generated by RefloQ AI